### PR TITLE
Properly clean up timer on flush

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -431,6 +431,11 @@ func (s *shards) runShard(i int) {
 	pendingSamples := model.Samples{}
 
 	timer := time.NewTimer(s.qm.cfg.BatchSendDeadline)
+	defer func() {
+		if !timer.Stop() {
+			<-timer.C
+		}
+	}()
 
 	for {
 		select {


### PR DESCRIPTION
This PR fixes a bug introduced in #3731

I believe this code at HEAD is leaking resources when the runShard() exits, e.g. on reshard. This change works for me locally and I see less CPU usage than before after a few reshardings. Both my low QPS and high QPS deployments seem to be working correctly with this change.

@tomwilkie